### PR TITLE
VoucherAmount check

### DIFF
--- a/Observatory/CodexReader.cs
+++ b/Observatory/CodexReader.cs
@@ -15,7 +15,7 @@ namespace Observatory
         public static void ProcessCodex(CodexEntry codexEntry)
 
         {
-                  if (Properties.Observatory.Default.SendToIGAU)
+                  if (Properties.Observatory.Default.SendToIGAU && codexEntry.VoucherAmount > 0)
                   {
                   JObject POST_content = JObject.FromObject(
                 new {


### PR DESCRIPTION
I think this should do the trick.  Luckily it's one aspect of C# that is similar to Python. 
All the detected CodeEntry events in the journal should appear in the main window, this change should only affect which ones get sent to IGAU. 

reference syntax I'm going off of from MSDN:

if (Value1 && Value2 > 0)